### PR TITLE
Feature/add change channel plugin

### DIFF
--- a/packages/server/core/TeamSpeak/plugins/changeChannel.js
+++ b/packages/server/core/TeamSpeak/plugins/changeChannel.js
@@ -1,0 +1,82 @@
+const Ts3 = require('../../TeamSpeak');
+const { convertToMiliseconds } = require('../../../utils/time');
+const log = require('../../../utils/log');
+const Cache = require('../../Cache');
+
+var loaded = [];
+
+module.exports.main = async (channel) => {
+	if (channel.enabled) {
+		let key = (await Cache.get(`changeChannel:${channel.channelId}`)) || 0;
+		Ts3.channelEdit(channel.channelId, channel.changes[key])
+			.then(async () => {
+				log.info(
+					`changeChannel - ch[id: ${channel.channelId}] to: ${channel.changes[key].channel_name}`,
+					'ts3'
+				);
+				await Cache.set(
+					`changeChannel:${channel.channelId}`,
+					channel.changes.length - 1 == key ? 0 : ++key
+				);
+			})
+			.catch((err) => {
+				log.error(`changeChannel - ch[id: ${channel.channelId}] Plugin error: ${err}`, 'ts3');
+			});
+	}
+};
+
+module.exports.load = async () => {
+	const { data } = this.info.config;
+	if (data.length > 0) {
+		data.forEach(async (channel) => {
+			if (channel.enabled) {
+				this.main(channel);
+				loaded[channel.channelId] = setInterval(async () => {
+					this.main(channel);
+				}, convertToMiliseconds(channel.interval));
+			}
+		});
+	}
+};
+
+module.exports.unload = () => {
+	loaded.forEach((load) => {
+		clearInterval(load);
+	});
+	loaded = [];
+};
+
+module.exports.info = {
+	name: 'changeChannel',
+	desc: 'Change channels.',
+	config: {
+		enabled: true,
+		data: [
+			{
+				enabled: true,
+				channelId: 118,
+				changes: [
+					{
+						channel_name: '[cspacer]Wellcome',
+						channel_description: 'Wellcome'
+					},
+					{
+						channel_name: '[cspacer]to',
+						channel_description: 'to'
+					},
+					{
+						channel_name: '[cspacer]SteamSpeak',
+						channel_description: 'SteamSpeak'
+					}
+				],
+				interval: {
+					weeks: 0,
+					days: 0,
+					hours: 0,
+					minutes: 0,
+					seconds: 3
+				}
+			}
+		]
+	}
+};

--- a/packages/server/core/TeamSpeak/plugins/multiFunction.js
+++ b/packages/server/core/TeamSpeak/plugins/multiFunction.js
@@ -1,0 +1,85 @@
+const Ts3 = require('../../TeamSpeak');
+const { convertToMiliseconds } = require('../../../utils/time');
+const log = require('../../../utils/log');
+
+var loaded = false;
+
+module.exports.main = async () => {
+	const { data } = this.info.config;
+	let info = await Ts3.serverInfo();
+	let channels = await Ts3.channelList();
+	let replacements = {
+		'[PING]': info.virtualserver_total_ping,
+		'[PACKETLOSS]': info.virtualserver_total_packetloss_total,
+		'[CHANNELS]': info.virtualserver_channelsonline,
+		'[UPLOAD]': info.virtualserver_total_bytes_uploaded,
+		'[DOWNLOAD]': info.virtualserver_total_bytes_downloaded
+	};
+	data.forEach((channel) => {
+		let name = channel.name;
+		for (var key in replacements) {
+			if (!replacements.hasOwnProperty(key)) continue;
+			name = name.replace(key, replacements[key]);
+		}
+		if (channels.find((c) => c.cid === channel.channelId && c.name !== name)) {
+			Ts3.channelEdit(channel.channelId, {
+				channel_name: name
+			});
+			log.info(`multiFunction - ch[id: ${channel.channelId}] to: ${name}`, 'ts3');
+		}
+	});
+};
+
+module.exports.load = async () => {
+	const { interval } = this.info.config;
+	this.main();
+	loaded = setInterval(async () => {
+		this.main();
+	}, convertToMiliseconds(interval));
+};
+
+module.exports.unload = () => {
+	clearInterval(loaded);
+};
+
+module.exports.info = {
+	name: 'multiFunction',
+	desc: 'Multiple funcitons to show server related data.',
+	config: {
+		enabled: true,
+		data: [
+			{
+				enabled: true,
+				channelId: 18,
+				name: '» Server ping: [PING]ms'
+			},
+			{
+				enabled: true,
+				channelId: 21,
+				name: '» Server packet loss: [PACKETLOSS]%'
+			},
+			{
+				enabled: true,
+				channelId: 19,
+				name: '» Channels count: [CHANNELS]'
+			},
+			{
+				enabled: true,
+				channelId: 24,
+				name: '» Bytes uploaded: [UPLOAD]'
+			},
+			{
+				enabled: true,
+				channelId: 25,
+				name: '» Bytes downloaded: [DOWNLOAD]'
+			}
+		],
+		interval: {
+			weeks: 0,
+			days: 0,
+			hours: 0,
+			minutes: 0,
+			seconds: 5
+		}
+	}
+};


### PR DESCRIPTION
## 🚀 Feature

Add change channel plugin to server.

### Have you read the [Contributing Guidelines on issues](https://github.com/dalexhd/steamspeak/blob/master/CONTRIBUTING.md#reporting-new-issues)?

Yes

## Motivation

Make SteamSpeak one of the best freebie and complete TeamSpeak bot available on the internet.

## Pitch

This feature allows changing channels properties at individual interval, for example:

Channel with id: 2 (interval 5 sec)
>1. Hello
>1. Wellcome
>1. To
>1. SteamSpeak's server

Channel with id: 4 (interval 3 sec)
>1. Create a
>1. free channel at
>1. Enter here to create a new channel