### PR TITLE
docs: Add dark default theme.

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -15,6 +15,7 @@ module.exports = {
     discordUrl: 'https://discord.gg/st4nsXw'
   },
   themeConfig: {
+    defaultDarkMode: true,
     navbar: {
       hideOnScroll: true,
       logo: {

--- a/docs/src/theme/Navbar/index.js
+++ b/docs/src/theme/Navbar/index.js
@@ -11,13 +11,7 @@ import useHideableNavbar from '@theme/hooks/useHideableNavbar';
 import useLockBodyScroll from '@theme/hooks/useLockBodyScroll';
 import useLogo from '@theme/hooks/useLogo';
 import { fetchNewRelease } from '@site/src/exports/newRelease';
-
 import styles from './styles.module.css';
-
-// TODO: Remove this line in next version
-if (typeof window !== 'undefined') {
-  localStorage.removeItem('theme');
-}
 
 function navLinkAttributes(label, right) {
   const attrs = { label };


### PR DESCRIPTION
## 📚 Documentation

Set dark theme as the default document theme.

### Have you read the [Contributing Guidelines on issues](https://github.com/dalexhd/steamspeak/blob/master/CONTRIBUTING.md#reporting-new-issues)?

Yes.

## Motivation
Save people's eyes

## Pitch
Improve documentation UX.
