### PR TITLE
Create groups only if connected.

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -35,7 +35,7 @@
     "push.js": "^1.0.12",
     "register-service-worker": "^1.7.1",
     "swiper": "^5.3.6",
-    "vee-validate": "^3.3.0",
+    "vee-validate": "^2.2.8",
     "vue": "^2.6.11",
     "vue-acl": "4.1.10",
     "vue-apexcharts": "^1.5.2",

--- a/packages/server/src/core/Cache/index.ts
+++ b/packages/server/src/core/Cache/index.ts
@@ -24,7 +24,7 @@ Pub.on('message', async (channel, key, paylaod) => {
 	let value = await Cache.get(key);
 	switch (channel) {
 		case EVENT_SET:
-			if (!key.includes('shadow:')) Cache.set(`shadow:${key}`, paylaod);
+			if (!key.includes('shadow:') && value) Cache.set(`shadow:${key}`, value);
 			if (config.debug) log.info(`Key "${key}" set!`, 'cache');
 			break;
 		case EVENT_EXPIRED:

--- a/packages/server/src/core/Steam/modules/richPresence.ts
+++ b/packages/server/src/core/Steam/modules/richPresence.ts
@@ -74,7 +74,7 @@ steamUser.on('user', async (sid, data) => {
 	//Check if the user is verified.
 	if (await VerifiedClient.exists({ steamId })) {
 		const user = await VerifiedClient.findOne({ steamId });
-		if (!user) return;
+		if (!user || !(await Ts3.getClientByUID(user.uid))) return;
 		if (typeof user.groupId === 'undefined') {
 			log.info('User has not group. Lets assign it.', 'steam');
 			groupNumber++;

--- a/yarn.lock
+++ b/yarn.lock
@@ -17124,10 +17124,10 @@ vdf@^0.0.2:
   dependencies:
     util "*"
 
-vee-validate@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/vee-validate/-/vee-validate-3.3.0.tgz#9f426831cbf8394860b948b30a7bcc6d2b5d173b"
-  integrity sha512-+QQZgA0I9ZTDsYNOSFlUqOvGIqW4yxjloxQCC6TD0rPn407G9hifn6RnId8kzl6+zHfl3/dE+bko49mYzgNNGg==
+vee-validate@^2.2.8:
+  version "2.2.15"
+  resolved "https://registry.yarnpkg.com/vee-validate/-/vee-validate-2.2.15.tgz#dc6c925d21e57288d3308fe5a39a0941036c575a"
+  integrity sha512-4TOsI8XwVkKVLkg8Nhmy+jyoJrR6XcTRDyxBarzcCvYzU61zamipS1WsB6FlDze8eJQpgglS4NXAS6o4NDPs1g==
 
 vendors@^1.0.0:
   version "1.0.4"


### PR DESCRIPTION
## 🐛 Bug Fix

TeamSpeak steam status groups are created even if the client is not connected to the server.

### Have you read the [Contributing Guidelines on issues](https://github.com/dalexhd/steamspeak/blob/master/CONTRIBUTING.md#reporting-new-issues)?

yes

## To Reproduce
1. A verified client launches steam.
1. This client is not connected on the TeamSpeak server.
1. A steam status group is created and assigned to it.

## Expected behavior

1. A verified client launches steam.
1. If the client is connected on the TeamSpeak server, a steam status group is created and assigned to it.