### PR TITLE
fix: Admin dashboard login.

### DIFF
--- a/packages/server/src/core/Website/api/controllers/auth.ts
+++ b/packages/server/src/core/Website/api/controllers/auth.ts
@@ -32,7 +32,7 @@ export const findClients = async function (
 		clients = clients.filter((client) => {
 			return config.admins.includes(client.uniqueIdentifier);
 		});
-		if (clients.length > 0) throw { statusCode: 400, message: lang.error.not_an_admin };
+		if (clients.length === 0) throw { statusCode: 400, message: lang.error.not_an_admin };
 	}
 	if (clients.length === 0) throw { statusCode: 404, message: lang.error.ip_not_connected };
 	return clients;


### PR DESCRIPTION
## 🐛 Bug Fix

Admin can't log in into the Admin Panel.

### Have you read the [Contributing Guidelines on issues](https://github.com/dalexhd/steamspeak/blob/master/CONTRIBUTING.md#reporting-new-issues)?

yes

## To Reproduce
1. An admin visits the SteamSpeak's panel.
1. Clicks login.
1. An error appears: `You are not authorized to access this site. Please request access to an administrator.'`

## Expected behavior

1. An admin visits the SteamSpeak's panel.
1. Clicks login.
1. The admin enters to the Admin Panel