### PR TITLE
chore(deps): bump ts3-nodejs-library from 2.4.4 to 3.0.4

### DIFF
--- a/.github/checklist.yml
+++ b/.github/checklist.yml
@@ -10,5 +10,3 @@ paths:
   "docs/**":
     - "Do you linted the code?"
     - "Have you added the new version on metadata.js?"
-  "packages/server/src/core/Website/api/controllers/auth.ts":
-    - "Do you replaced findClients() IP variable?"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,13 +5,23 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "type": "node",
-            "request": "launch",
-            "name": "Iniciar programa",
-            "skipFiles": [
-                "<node_internals>/**"
-            ],
-            "program": "${workspaceFolder}\\packages\\server\\index.js"
+          //TODO: Fix hot reaload creating multiple instances in DEV environment.
+          "name": "ts-node-dev",
+          "type": "node",
+          "request": "launch",
+          "protocol": "inspector",
+          "cwd": "${workspaceRoot}/packages/server",
+          "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/ts-node-dev",
+          "args": [
+              "-r",
+              "tsconfig-paths/register",
+              "${workspaceRoot}/packages/server/src/index.ts"
+          ],
+          "restart": true,
+          "env": {
+            "TS_NODE_FILES": "true",
+            "NODE_ENV": "production"
+          }
         }
     ]
 }

--- a/docs/docs/reference/plugins/afk-kick.md
+++ b/docs/docs/reference/plugins/afk-kick.md
@@ -29,8 +29,8 @@ export const info: CommonPluginConfig = {
 				weeks: 0,
 				days: 0,
 				hours: 0,
-				minutes: 0,
-				seconds: 5
+				minutes: 30,
+				seconds: 0
 			}
 		},
 		interval: {
@@ -38,7 +38,7 @@ export const info: CommonPluginConfig = {
 			days: 0,
 			hours: 0,
 			minutes: 0,
-			seconds: 5
+			seconds: 10
 		}
 	}
 };

--- a/docs/docs/reference/plugins/afk-move.md
+++ b/docs/docs/reference/plugins/afk-move.md
@@ -24,14 +24,13 @@ export const info: CommonPluginConfig = {
 	config: {
 		enabled: false,
 		data: {
-			goBack: true,
 			dest: 2,
 			minTime: {
 				weeks: 0,
 				days: 0,
 				hours: 0,
-				minutes: 0,
-				seconds: 5
+				minutes: 20,
+				seconds: 0
 			}
 		},
 		interval: {
@@ -39,7 +38,7 @@ export const info: CommonPluginConfig = {
 			days: 0,
 			hours: 0,
 			minutes: 0,
-			seconds: 5
+			seconds: 10
 		}
 	}
 };

--- a/docs/docs/reference/plugins/change-channel.md
+++ b/docs/docs/reference/plugins/change-channel.md
@@ -21,23 +21,23 @@ export const info: UncommonPluginConfig = {
 	name: 'Change channel',
 	description: 'This plugin allows you to change multiple channels name at different interval.',
 	config: {
-		enabled: true,
+		enabled: false,
 		data: [
 			{
 				enabled: false,
 				channelId: 118,
 				changes: [
 					{
-						channel_name: '[cspacer]Welcome',
-						channel_description: 'Welcome'
+						channelName: '[cspacer]Welcome',
+						channelDescription: 'Welcome'
 					},
 					{
-						channel_name: '[cspacer]to',
-						channel_description: 'to'
+						channelName: '[cspacer]to',
+						channelDescription: 'to'
 					},
 					{
-						channel_name: '[cspacer]SteamSpeak',
-						channel_description: 'SteamSpeak'
+						channelName: '[cspacer]SteamSpeak',
+						channelDescription: 'SteamSpeak'
 					}
 				],
 				interval: {
@@ -45,10 +45,11 @@ export const info: UncommonPluginConfig = {
 					days: 0,
 					hours: 0,
 					minutes: 0,
-					seconds: 3
+					seconds: 5
 				}
 			}
 		]
 	}
 };
+
 ```

--- a/docs/docs/reference/plugins/multi-function.md
+++ b/docs/docs/reference/plugins/multi-function.md
@@ -54,8 +54,8 @@ export const info: CommonPluginConfig = {
 			weeks: 0,
 			days: 0,
 			hours: 0,
-			minutes: 0,
-			seconds: 5
+			minutes: 5,
+			seconds: 0
 		}
 	}
 };

--- a/packages/client/src/layouts/components/navbar/components/ProfileDropDown.vue
+++ b/packages/client/src/layouts/components/navbar/components/ProfileDropDown.vue
@@ -1,8 +1,8 @@
 <template>
-	<div v-if="activeUserInfo.client_nickname" class="the-navbar__user-meta flex items-center">
+	<div v-if="activeUserInfo.clientNickname" class="the-navbar__user-meta flex items-center">
 		<div class="text-right leading-tight hidden sm:block">
 			<p class="font-semibold">
-				{{ activeUserInfo.client_nickname }}
+				{{ activeUserInfo.clientNickname }}
 			</p>
 			<small>Available</small>
 		</div>

--- a/packages/client/src/views/pages/login/components/Ts3.vue
+++ b/packages/client/src/views/pages/login/components/Ts3.vue
@@ -17,8 +17,8 @@
 						<vs-select-item
 							v-for="(client, index) in clients"
 							:key="index"
-							:value="client.client_database_id"
-							:text="client.client_nickname"
+							:value="client.clientDatabaseId"
+							:text="client.clientNickname"
 						/>
 					</vs-select>
 					<vs-button @click="send">Send code</vs-button>

--- a/packages/client/src/views/public/login/components/Ts3.vue
+++ b/packages/client/src/views/public/login/components/Ts3.vue
@@ -17,8 +17,8 @@
 						<vs-select-item
 							v-for="(client, index) in clients"
 							:key="index"
-							:value="client.client_database_id"
-							:text="client.client_nickname"
+							:value="client.clientDatabaseId"
+							:text="client.clientNickname"
 						/>
 					</vs-select>
 					<vs-button @click="send">Send code</vs-button>

--- a/packages/client/src/views/public/verify/Verify.vue
+++ b/packages/client/src/views/public/verify/Verify.vue
@@ -25,8 +25,8 @@
 										<vs-select-item
 											v-for="(client, index) in clients"
 											:key="index"
-											:value="client.client_database_id"
-											:text="client.client_nickname"
+											:value="client.clientDatabaseId"
+											:text="client.clientNickname"
 										/>
 									</vs-select>
 									<div class="flex justify-left flex-wrap mt-4">

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -3,8 +3,8 @@
   "version": "0.7.0",
   "main": "index.js",
   "scripts": {
-    "start": "cross-env TS_NODE_FILES=true NODE_ENV=production TS_NODE_FILES=true ts-node -r tsconfig-paths/register src/index.ts",
-    "dev": "cross-env NODE_ENV=development TS_NODE_FILES=true ts-node-dev -r tsconfig-paths/register src/index.ts",
+    "start": "cross-env TS_NODE_FILES=true NODE_ENV=production ts-node -r tsconfig-paths/register src/index.ts",
+    "dev": "cross-env NODE_ENV=development TS_NODE_FILES=true ts-node-dev --exit-child -r tsconfig-paths/register src/index.ts",
     "prestart": "cd ../../ && make check-config",
     "test": "jest tests/ --runInBand",
     "lint": "eslint '*/**/*.{js,ts}' --quiet --fix"
@@ -40,7 +40,7 @@
     "steam-user": "^4.13.2",
     "steamcommunity": "^3.41.3",
     "steamid": "^1.1.3",
-    "ts3-nodejs-library": "^2.4.1"
+    "ts3-nodejs-library": "^3.0.4"
   },
   "bugs": {
     "url": "https://github.com/dalexhd/SteamSpeak/issues"

--- a/packages/server/src/core/Database/models/verifiedClient.ts
+++ b/packages/server/src/core/Database/models/verifiedClient.ts
@@ -8,12 +8,12 @@ const VerifiedClientSchema = new Schema({
 		index: true,
 		unique: true
 	},
-	dbid: Number,
+	dbid: String,
 	steamId: {
 		type: String,
 		unique: true
 	},
-	groupId: Number,
+	groupId: String,
 	groupNumber: Number
 });
 

--- a/packages/server/src/core/Steam/games/csgo.ts
+++ b/packages/server/src/core/Steam/games/csgo.ts
@@ -34,10 +34,11 @@ export const main = async function (
 		});
 		queue.on('task_finish', function (taskId, result) {
 			const rankId = result.response.ranking.rank_id;
-			const nextRankGroupId = info.config.data.ranks[rankId];
+			const nextRankGroupId = info.config.data.ranks[rankId].toString();
 			const delGroups = client?.servergroups?.filter(
 				(serverGroup) =>
-					info.config.data.ranks.includes(serverGroup) && serverGroup !== nextRankGroupId
+					info.config.data.ranks.map(String).includes(serverGroup) &&
+					serverGroup !== nextRankGroupId
 			);
 			if (delGroups && delGroups.length > 0) {
 				client?.delGroups(delGroups);

--- a/packages/server/src/core/Steam/index.ts
+++ b/packages/server/src/core/Steam/index.ts
@@ -141,7 +141,7 @@ function loadModules(): void {
  */
 async function initUsers(): Promise<void> {
 	const connectedClients = await Ts3.clientList({
-		client_type: 0
+		clientType: 0
 	});
 	const verifiedUsers = await VerifiedClient.find({
 		uid: { $in: connectedClients.map((client) => client.uniqueIdentifier) }

--- a/packages/server/src/core/Steam/modules/friendRequest.ts
+++ b/packages/server/src/core/Steam/modules/friendRequest.ts
@@ -75,14 +75,9 @@ const friendDeleted = async (senderID): Promise<void> => {
 	const steamId = senderID.getSteamID64();
 	const User = await VerifiedClient.findOne({ steamId });
 	if (User) {
-		const [client] = await Ts3.clientList({
-			client_type: 0,
-			client_unique_identifier: User.uid
-		});
+		const client = await Ts3.getClientByUid(User.uid);
 		User.remove(() => {
-			if (client) {
-				client.poke(lang.steam.friend.deleted);
-			}
+			client?.poke(lang.steam.friend.deleted);
 		});
 	}
 };

--- a/packages/server/src/core/TeamSpeak/plugins/first-instance/multi_function.ts
+++ b/packages/server/src/core/TeamSpeak/plugins/first-instance/multi_function.ts
@@ -8,11 +8,11 @@ export const main = async function (): Promise<void> {
 	const { data } = info.config;
 	const serverInfo = await Ts3.serverInfo();
 	const replacements = {
-		'[PING]': serverInfo.virtualserver_total_ping,
-		'[PACKETLOSS]': serverInfo.virtualserver_total_packetloss_total,
-		'[CHANNELS]': serverInfo.virtualserver_channelsonline,
-		'[UPLOAD]': serverInfo.virtualserver_total_bytes_uploaded,
-		'[DOWNLOAD]': serverInfo.virtualserver_total_bytes_downloaded
+		'[PING]': serverInfo.virtualserverTotalPing,
+		'[PACKETLOSS]': serverInfo.virtualserverTotalPacketlossTotal,
+		'[CHANNELS]': serverInfo.virtualserverChannelsonline,
+		'[UPLOAD]': serverInfo.virtualserverTotalBytesUploaded,
+		'[DOWNLOAD]': serverInfo.virtualserverTotalBytesDownloaded
 	};
 	data.forEach((channel) => {
 		let name = channel.name;
@@ -21,13 +21,12 @@ export const main = async function (): Promise<void> {
 			name = name.replace(key, replacements[key]);
 		}
 		Ts3.channelEdit(channel.channelId, {
-			channel_name: name
+			channelName: name
 		})
 			.then(() => {
 				log.info(`${info.name} ch[id: ${channel.channelId}] to: ${name}`, 'ts3');
 			})
 			.catch((err) => {
-				if (err.id === 771) return;
 				log.error(`${info.name} ch[id: ${channel.channelId}] error: ${err}`, 'ts3');
 			});
 	});
@@ -82,8 +81,8 @@ export const info: CommonPluginConfig = {
 			weeks: 0,
 			days: 0,
 			hours: 0,
-			minutes: 0,
-			seconds: 5
+			minutes: 5,
+			seconds: 0
 		}
 	}
 };

--- a/packages/server/src/core/TeamSpeak/plugins/second-instance/afk_kick.ts
+++ b/packages/server/src/core/TeamSpeak/plugins/second-instance/afk_kick.ts
@@ -2,12 +2,13 @@ import { Ts3 } from '@core/TeamSpeak';
 import { convertToMilliseconds } from '@utils/time';
 import log from '@utils/log';
 import Cache from '@core/Cache';
+import { ClientDisconnectEvent } from 'ts3-nodejs-library';
 
 let loaded: ReturnType<typeof setInterval>;
 
 export const main = async function (): Promise<void> {
 	const { data } = info.config;
-	const clients = await Ts3.clientList({ client_type: 0 });
+	const clients = await Ts3.clientList({ clientType: 0 });
 	clients.forEach(async (client) => {
 		if (client.isAfk(data.interval) && client.cid !== data.dest) {
 			client.kickFromServer("You've been kicked out for being afk");
@@ -27,9 +28,9 @@ export const unload = async function (): Promise<void> {
 	clearInterval(loaded);
 };
 
-export const clientdisconnect = async function (ev): Promise<void> {
+export const clientdisconnect = async function (ev: ClientDisconnectEvent): Promise<void> {
 	const { client } = ev;
-	if (client.type !== 1) {
+	if (client?.type === 1) {
 		Cache.del(`afkChecker:${client.databaseId}`);
 	}
 };
@@ -46,8 +47,8 @@ export const info: CommonPluginConfig = {
 				weeks: 0,
 				days: 0,
 				hours: 0,
-				minutes: 0,
-				seconds: 5
+				minutes: 30,
+				seconds: 0
 			}
 		},
 		interval: {
@@ -55,7 +56,7 @@ export const info: CommonPluginConfig = {
 			days: 0,
 			hours: 0,
 			minutes: 0,
-			seconds: 5
+			seconds: 10
 		}
 	}
 };

--- a/packages/server/src/core/TeamSpeak/plugins/second-instance/change_channel.ts
+++ b/packages/server/src/core/TeamSpeak/plugins/second-instance/change_channel.ts
@@ -11,7 +11,7 @@ export const main = async function (channel): Promise<void> {
 		Ts3.channelEdit(channel.channelId, channel.changes[key])
 			.then(async () => {
 				log.info(
-					`${info.name} ch[id: ${channel.channelId}] to: ${channel.changes[key].channel_name}`,
+					`${info.name} ch[id: ${channel.channelId}] to: ${channel.changes[key].channelName}`,
 					'ts3'
 				);
 				await Cache.set(
@@ -20,12 +20,6 @@ export const main = async function (channel): Promise<void> {
 				);
 			})
 			.catch((err) => {
-				if (err.id === 771) {
-					return Cache.set(
-						`changeChannel:${channel.channelId}`,
-						channel.changes.length - 1 == key ? 0 : ++key
-					);
-				}
 				log.error(`${info.name} ch[id: ${channel.channelId}] error: ${err}`, 'ts3');
 			});
 	}
@@ -58,20 +52,20 @@ export const info: UncommonPluginConfig = {
 		enabled: false,
 		data: [
 			{
-				enabled: true,
+				enabled: false,
 				channelId: 118,
 				changes: [
 					{
-						channel_name: '[cspacer]Welcome',
-						channel_description: 'Welcome'
+						channelName: '[cspacer]Welcome',
+						channelDescription: 'Welcome'
 					},
 					{
-						channel_name: '[cspacer]to',
-						channel_description: 'to'
+						channelName: '[cspacer]to',
+						channelDescription: 'to'
 					},
 					{
-						channel_name: '[cspacer]SteamSpeak',
-						channel_description: 'SteamSpeak'
+						channelName: '[cspacer]SteamSpeak',
+						channelDescription: 'SteamSpeak'
 					}
 				],
 				interval: {
@@ -79,7 +73,7 @@ export const info: UncommonPluginConfig = {
 					days: 0,
 					hours: 0,
 					minutes: 0,
-					seconds: 3
+					seconds: 5
 				}
 			}
 		]

--- a/packages/server/src/core/Website/api/controllers/verify.ts
+++ b/packages/server/src/core/Website/api/controllers/verify.ts
@@ -30,7 +30,7 @@ export const check = async function (req: Request, res: Response): Promise<any> 
 	try {
 		const steamData = await findSecret(req);
 		const clients = await findClients(req, {
-			client_type: 0
+			clientType: 0
 		});
 		res.status(200).json({ steam: steamData, clients });
 	} catch (error) {
@@ -52,8 +52,8 @@ export const send = async function (req: Request, res: Response): Promise<any> {
 	try {
 		const steamData = await findSecret(req);
 		const [client] = await findClients(req, {
-			client_type: 0,
-			client_database_id: req.body.dbid
+			clientType: 0,
+			clientDatabaseId: req.body.dbid
 		});
 		const token = crypto.randomBytes(3).toString('hex');
 		client
@@ -94,8 +94,8 @@ export const login = async function (req: Request, res: Response): Promise<any> 
 	try {
 		const steamData = await findSecret(req);
 		const [client] = await findClients(req, {
-			client_type: 0,
-			client_database_id: req.body.dbid
+			clientType: 0,
+			clientDatabaseId: req.body.dbid
 		});
 		const sendCache = JSON.parse((await Cache.get(`${client.databaseId}:verifyToken`)) as string);
 

--- a/packages/server/src/core/Website/api/middlewares/authentication.ts
+++ b/packages/server/src/core/Website/api/middlewares/authentication.ts
@@ -20,8 +20,7 @@ export const authenticate = async function (
 		}
 		// 2) verify token
 		const decoded = jwt.verify(token, config.jwt.secret) as { uid: string };
-		const client = await Ts3.getClientByUID(decoded.uid);
-		req.client = client;
+		req.client = await Ts3.getClientByUid(decoded.uid);
 		req.role = 'admin';
 		req.token = token;
 		next();

--- a/packages/server/src/tests/TeamSpeak3/teamspeak.spec.ts
+++ b/packages/server/src/tests/TeamSpeak3/teamspeak.spec.ts
@@ -23,11 +23,11 @@ describe('TeamSpeak3', () => {
 	});
 	describe('Commands', () => {
 		it('should verify parameters of #serverGroupClientList()', async () => {
-			const data = Ts3.serverGroupClientList(1);
+			const data = Ts3.serverGroupClientList('1');
 			expect(data).not.toBe(null);
 		});
 		it('should verify parameters of #sendTextMessage()', async () => {
-			const data = await Ts3.sendTextMessage(10, 2, 'Test message');
+			const data = await Ts3.sendTextMessage('10', 2, 'Test message');
 			expect(data).not.toBe(null);
 		});
 	});

--- a/packages/server/src/types/database.d.ts
+++ b/packages/server/src/types/database.d.ts
@@ -3,7 +3,7 @@ import { Document } from 'mongoose';
 declare global {
 	interface VerifiedClientDocument extends Document {
 		uid: string;
-		dbid: number;
+		dbid: string;
 		steamId: string;
 		groupId: any;
 		groupNumber: any;

--- a/packages/server/src/types/teamspeak.d.ts
+++ b/packages/server/src/types/teamspeak.d.ts
@@ -59,12 +59,12 @@ declare module 'ts3-nodejs-library' {
 
 declare module 'ts3-nodejs-library/lib/types/ResponseTypes' {
 	interface ServerInfo {
-		virtualserver_total_ping: number;
-		virtualserver_total_packetloss_total: number;
-		virtualserver_channelsonline: number;
-		virtualserver_total_bytes_uploaded: number;
-		virtualserver_total_bytes_downloaded: number;
-		virtualserver_clientsonline: number;
-		virtualserver_queryclientsonline: number;
+		virtualserverTotalPing: number;
+		virtualserverTotalPacketlossTotal: number;
+		virtualserverChannelsonline: number;
+		virtualserverTotalBytesUploaded: number;
+		virtualserverTotalBytesDownloaded: number;
+		virtualserverClientsonline: number;
+		virtualserverQueryclientsonline: number;
 	}
 }

--- a/packages/server/src/utils/log.ts
+++ b/packages/server/src/utils/log.ts
@@ -45,8 +45,7 @@ const Log = {
 					break;
 			}
 			let instance = '';
-			if (process.env.INSTANCE)
-				instance = chalk.bgGreen.black(`[${startCase(process.env.INSTANCE)}]`);
+			if (process.env.INSTANCE) instance = chalk.black(`[${startCase(process.env.INSTANCE)}]`);
 			prefix = chalk.cyan(
 				`[${this.time()}]${chalk[color].bold(
 					` ${instance}[${type.charAt(0).toUpperCase()}${type.slice(1)}]`
@@ -113,7 +112,7 @@ const Log = {
 	 * @param {string} type Optional type
 	 */
 	success(log: string, type?: string): void {
-		this.print(log, '#007E33', type);
+		this.print(log, '#28A745', type);
 	},
 
 	/**

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -18,7 +18,7 @@
         "@locales/*": ["src/locales/*"],
         "@utils/*": ["src/utils/*"]
       },
-      "typeRoots": ["ts3-nodejs-library", "../../node_modules/@types", "./src/types"]
+      "typeRoots": ["../../node_modules/ts3-nodejs-library/src/types", "../../node_modules/@types", "./src/types"],
   },
   "include": [
       "./src/**/*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4801,7 +4801,7 @@ btoa-lite@^1.0.0:
   resolved "https://registry.yarnpkg.com/btoa-lite/-/btoa-lite-1.0.0.tgz#337766da15801210fdd956c22e9c6891ab9d0337"
   integrity sha1-M3dm2hWAEhD92VbCLpxokaudAzc=
 
-buffer-crc32@^0.2:
+buffer-crc32@^0.2, buffer-crc32@^0.2.13:
   version "0.2.13"
   resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
   integrity sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=
@@ -16797,11 +16797,12 @@ ts-pnp@^1.1.6:
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
   integrity sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==
 
-ts3-nodejs-library@^2.4.1:
-  version "2.4.4"
-  resolved "https://registry.yarnpkg.com/ts3-nodejs-library/-/ts3-nodejs-library-2.4.4.tgz#70cdaa2684f7e4cdcacc07f2db1743095853774f"
-  integrity sha512-rO/CfmiNUt4/D7er6HtyMN538XzOSJ4lQoP+JQBz7acf7YrdFJtc5o75F6mTE1OhPywLSKSfyWKJMYJeDN3bKA==
+ts3-nodejs-library@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/ts3-nodejs-library/-/ts3-nodejs-library-3.0.4.tgz#7cebf8e2eadcc9457fcd4a7789df2a1bfa0ac480"
+  integrity sha512-TGb/0CW93LWiUpbJ1BeaG1wX5Cgstwq7XT1na/RSY10l3gqSY0sqCQTSKnwlSl/aXQDcwwzQDsP1anHk69lViw==
   dependencies:
+    buffer-crc32 "^0.2.13"
     ssh2 "^0.8.9"
 
 tsconfig-paths@^3.9.0:


### PR DESCRIPTION
https://github.com/Multivit4min/TS3-NodeJS-Library
Bumps [ts3-nodejs-library](https://github.com/Multivit4min/TS3-NodeJS-Library) from 2.4.4 to 3.0.4.
- [Changelog](https://github.com/Multivit4min/TS3-NodeJS-Library/blob/3.x/CHANGELOG.md)
- [Commits](https://github.com/Multivit4min/TS3-NodeJS-Library/compare/3.x)

Breaking changes:
1. Plugins
[afk kick]
- Changed plugin interval from "seconds: 5" to "seconds: 10"
- Changed kick interval from "seconds: 5" to "minutes: 30"
[afk move]
- Changed plugin interval from "seconds: 5" to "seconds: 10"
- Changed move interval from "seconds: 5" to "minutes: 20"
[change channel]
- Now it's disabled by default
- Replaced config data changes keys. From channel_name to channelName & channel_description to channelDescription
- Changed plugin interval from "seconds: 3" to "seconds: 5"
[multi function]
- Changed plugin interval from "seconds: 5" to "minutes: 5"
2. Database
[verified client]
- Changed dbid type from number to string.
- Changed groupId type from number to string.
(NOTE: You'll need to update your database manually)

Notes:
1. Steam Modules
[rich presence]
- Now SteamSpeak uses Regex to filter steamGroups. The used regex is: https://regex101.com/r/TexROh/1
  IMPORTANT: Now groups (only if the group has query type and namemode is set to 2) that contains "#[number] [rich presence]" are considered SteamSpeak groups. This means that you should not create a group with the same pattern and same properties to prevent SteamSpeak deleting them. This is done to prevent group duplication bug.